### PR TITLE
Fixes and date format

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,39 +23,38 @@
         var res1 = track[1].match(/(\%)([A-Z]{2})([^\^]{0,13})\^?([^\^]{0,35})\^?([^\^]{0,29})\^?\s*?\?/);
         var res2 = track[2].match(/(;)(\d{6})(\d{0,13})(\=)(\d{4})(\d{8})(\d{0,5})\=?\?/);
         var res3 = track[3].match(/(\#|\%|\+)(\d|\!|\")(\d|\s)([0-9A-Z ]{11})([0-9A-Z ]{2})([0-9A-Z ]{10})([0-9A-Z ]{4})([12 ]{1})([0-9A-Z ]{3})([0-9A-Z ]{3})([0-9A-Z ]{3})([0-9A-Z ]{3})(.*?)\?/);
+        var state = res1[2];
         return {
-            "state": res1[2],
+            "state": state,
             "city": res1[3],
             "name": function() {
                 var res = res1[4].match(/([^\$]{0,35})\$?([^\$]{0,35})?\$?([^\$]{0,35})?/);
+                if (!res) return;
                 return {
                     last: res[1],
                     first: res[2],
                     middle: res[3]
                 }
-            },
+            }(),
             "address": res1[5],
             "iso_iin": res2[2],
             "dl": res2[3],
             "expiration_date": res2[5],
             "birthday": function() {
-                var dob = res2[6].match(/(\d{4})(\d{2})(\d{2})/);
-                dob[1] = parseInt(dob[1]);
-                dob[2] = parseInt(dob[2]);
-                dob[3] = parseInt(dob[3]);
+              var dob = res2[6].match(/(\d{4})(\d{2})(\d{2})/);
+              if (!dob) return;
 
-                if (dob[2] === 99) {
-                    /* FL decided to reverse 2012 aamva spec, 99 means here 
-                        that dob month === to expiration month, it should be 
-                        opposite
-                        */
-                    var exp_dt = res2[5].match(/(\d{2})(\d{2})/);
-                    dob[2] = parseInt(exp_dt[2]);
-                }
-                dob[2]--;
-
-                return (new Date(Date.UTC(dob[1], dob[2], dob[3])));
-            },
+              if (dob[2] === '99') {
+                  /* FL decided to reverse 2012 aamva spec, 99 means here 
+                      that dob month === to expiration month, it should be 
+                      opposite
+                      */
+                  var exp_dt = res2[5].match(/(\d{2})(\d{2})/);
+                  dob[2] = exp_dt[2];
+              }
+              //dob[2]--; what was this for?
+              return dob[1] + dob[2] + dob[3];
+            }(),
             "dl_overflow": res2[7],
             "cds_version": res3[1],
             "jurisdiction_version": res3[2],
@@ -75,7 +74,7 @@
                         return "MISSING/INVALID";
                         break;
                 }
-            },
+            }(),
             "height": res3[9],
             "weight": res3[10],
             "hair_color": res3[11],
@@ -83,9 +82,10 @@
             "misc": res3[13],
             "id": function(){
                 var id;
-                switch(this.state) {
+                switch(state) {
                     case "FL":
                         var res = res2[3].match(/(\d{2})(.*)/);
+                        if (!res) return;
                         id = (String.fromCharCode(Number(res[1]) + 64)  + res[2] + res2[7]);   
                         break;                 
                     default:
@@ -93,7 +93,7 @@
                         break;
                 }
                 return id;
-            }
+            }()
         };
     };
     
@@ -374,23 +374,16 @@
                     first: parsedData.DAC,
                     middle: parsedData.DAD
                 }
-            },
+            }(),
             "address": parsedData.DAG,
             "iso_iin": undefined,
             "dl": parsedData.DAQ,
             "expiration_date": parsedData.DBA,
             "birthday": function() {
-                var dob = parsedData.DBB.match(/(\d{2})(\d{2})(\d{4})/);
-                dob[1] = parseInt(dob[1]);
-                dob[2] = parseInt(dob[2]);
-                dob[3] = parseInt(dob[3]);
-
-                return (
-                    new Date(
-                        Date.UTC(dob[3], dob[1], dob[2]) 
-                    ) 
-                );
-            },
+              var match = parsedData.DBB.match(/(\d{2})(\d{2})(\d{4})/);
+              if (!match) return;
+              return match[3] + match[1] + match[2];
+            }(),
             "dl_overflow": undefined,
             "cds_version": undefined,
             "jurisdiction_version": undefined,
@@ -410,15 +403,16 @@
                         return "MISSING/INVALID";
                         break;
                 }
-            },
+            }(),
             "height": undefined,
             "weight": undefined,
             "hair_color": undefined,
             "eye_color": undefined,
             "misc": undefined,
             "id": function(){
+                if (!parsedData.DAQ) return;
                 return parsedData.DAQ.replace(/[^A-ZA-Z0-9]/g, "");
-            }
+            }()
         };
 
         return rawData;

--- a/index.js
+++ b/index.js
@@ -125,7 +125,7 @@
                 '(DBA.*?)?' + // Driver License Expiration Date
                 '(DBB.*?)?' + // Date of Birth
                 '(DBC.*?)?' + // Driver Sex
-                '(DBD.*?)'    // Driver License or ID Document Issue Date
+                '(DBD.*?)?' + // Driver License or ID Document Issue Date
                 /* optional 
                 '(DAU.*?)?' + // Height (FT/IN)
                 '(DAW.*?)?' + // Weight (LBS)
@@ -166,6 +166,7 @@
                 '(DBR.*?)?' + // Driver "AKA" Suffix
                 '(DBS.*?)?'   // Driver "AKA" Prefix
                 */
+                '$'
             );    
         }
         /* version 02 year 2003 */
@@ -195,7 +196,7 @@
                 '(DAQ.*?)?' + // Customer ID Number
                 '(DCF.*?)?' + // Document Discriminator
                 '(DCG.*?)?' + // Country Identification
-                '(DCH.*?)?'    // Federal Commercial Vehicle Codes
+                '(DCH.*?)?' + // Federal Commercial Vehicle Codes
 
                 /* optional elements 
                 '(DAH.*?)?' + // Address – Street 2
@@ -213,30 +214,31 @@
                 '(DCQ.*?)?' + // Jurisdiction- specific endorsement code description
                 '(DCR.*?)?'  // Jurisdiction- specific restriction code description
                 */
+                '$'
             );
         }
         /* version 03 year 2005 */
         else if ( Number(version[1]) === 3) {
             parseRegex = new RegExp(
-                '(DCA.*?)' + // Jurisdiction-specific vehicle class
-                '(DCB.*?)' + // Jurisdiction-specific restriction codes
-                '(DCD.*?)' + // Jurisdiction-specific endorsement codes
-                '(DBA.*?)' + // Document Expiration Date
-                '(DCS.*?)' + // Customer Family Name
-                '(DCT.*?)' + // Customer Given Names
-                '(DBD.*?)' + // Document Issue Date
-                '(DBB.*?)' + // Date of Birth
-                '(DBC.*?)' + // Physical Description – Sex
-                '(DAY.*?)' + // Physical Description – Eye Color
-                '(DAU.*?)' + // Physical Description – Height
-                '(DAG.*?)' + // Address – Street 1
-                '(DAI.*?)' + // Address – City
-                '(DAJ.*?)' + // Address – Jurisdiction Code
-                '(DAK.*?)' + // Address – Postal Code
-                '(DAQ.*?)' + // Customer ID Number
-                '(DCF.*?)' + // Document Discriminator
-                '(DCG.*?)' + // Country Identification
-                '(DCH.*?)'   // Federal Commercial Vehicle Codes
+                '(DCA.*?)?' + // Jurisdiction-specific vehicle class
+                '(DCB.*?)?' + // Jurisdiction-specific restriction codes
+                '(DCD.*?)?' + // Jurisdiction-specific endorsement codes
+                '(DBA.*?)?' + // Document Expiration Date
+                '(DCS.*?)?' + // Customer Family Name
+                '(DCT.*?)?' + // Customer Given Names
+                '(DBD.*?)?' + // Document Issue Date
+                '(DBB.*?)?' + // Date of Birth
+                '(DBC.*?)?' + // Physical Description – Sex
+                '(DAY.*?)?' + // Physical Description – Eye Color
+                '(DAU.*?)?' + // Physical Description – Height
+                '(DAG.*?)?' + // Address – Street 1
+                '(DAI.*?)?' + // Address – City
+                '(DAJ.*?)?' + // Address – Jurisdiction Code
+                '(DAK.*?)?' + // Address – Postal Code
+                '(DAQ.*?)?' + // Customer ID Number
+                '(DCF.*?)?' + // Document Discriminator
+                '(DCG.*?)?' + // Country Identification
+                '(DCH.*?)?' + // Federal Commercial Vehicle Codes
                 /* optional elements 
                 + '(DAH.*?)?' + // Address – Street 2
                 '(DAZ.*?)?' + // Hair color
@@ -256,6 +258,7 @@
                 '(DCQ.*?)?' + // Jurisdiction- specific endorsement code description
                 '(DCR.*?)?'  // Jurisdiction- specific restriction code description
                 */
+                '$'
             );
         }
         /* version 07 year 2012 */
@@ -282,7 +285,7 @@
                 '(DCG.*?)?' + // Country Identification
                 '(DDE.*?)?' + // Family name truncation
                 '(DDF.*?)?' + // First name truncation
-                '(DDG.*?)'    // Middle name truncation
+                '(DDG.*?)?' + // Middle name truncation
                 /* optional elements 
                 '(DAH.*?)?' + // Address – Street 2
                 '(DAZ.*?)?' + // Hair color
@@ -313,6 +316,7 @@
                 '(DDK.*?)?' + // Organ Donor Indicator
                 '(DDL.*?)?'   // Veteran Indicator
                 */
+                '$'
             );
         } 
         else {

--- a/index.js
+++ b/index.js
@@ -394,7 +394,7 @@
             "dl_overflow": undefined,
             "cds_version": undefined,
             "jurisdiction_version": undefined,
-            "postal_code": parsedData.DAK.match(/\d{-}\d+/)? parsedData.DAK : parsedData.DAK.substring(0,5),
+            "postal_code": parsedData.DAK ? (parsedData.DAK.match(/\d{-}\d+/) ? parsedData.DAK : parsedData.DAK.substring(0,5)) : undefined,
             "class": parsedData.DCA,
             "restrictions": undefined,
             "endorsments": undefined,

--- a/test/FL.js
+++ b/test/FL.js
@@ -23,19 +23,19 @@ describe('city', function() {
 
 describe('DMV ID', function() {
     it('should be set to D621720820090', function(){
-    	expect(stripe.id()).to.equal("D621720820090");
+    	expect(stripe.id).to.equal("D621720820090");
     });
 });
 
 describe('First name', function() {
     it('should be set to JOHN', function(){
-    	expect(stripe.name().first).to.equal("JOHN");
+    	expect(stripe.name.first).to.equal("JOHN");
     });
 });
 
 describe('Last name', function() {
     it('should be set to DOE', function(){
-    	expect(stripe.name().last).to.equal("DOE");
+    	expect(stripe.name.last).to.equal("DOE");
     });
 });
 
@@ -47,13 +47,12 @@ describe('Address', function() {
 
 describe('Sex', function() {
     it('should be set to MALE', function(){
-    	expect(stripe.sex()).to.equal("MALE");
+    	expect(stripe.sex).to.equal("MALE");
     });
 });
 
 describe('DOB', function() {
     it('should be set to 19870108', function(){
-        var date = new Date(Date.UTC(1987,0,8));
-        expect(stripe.birthday().toDateString()).to.equal(date.toDateString());
+        expect(stripe.birthday).to.equal('19870108')
     });
 });

--- a/test/PDF417_CT.js
+++ b/test/PDF417_CT.js
@@ -2,7 +2,7 @@ var should = require('chai').should(),
     expect = require('chai').expect,
     aamva = require('../index');
 
-var data = '@AMVA 6360060101DL00290198DAAREGULARLPSAMPLE,SELECTCTID,A,3RDDAG60 STATE STDAIWETHERSFIELDDAJCTDAK061091896  DAQ119000555DARD   DASB         DAT     DBA20131107DBB19951107DBC1DBD20111115DAU601DAYBLUDBF00DBHY';
+var data = '@AMVA 6360060101DL00290198DAAREGULARLPSAMPLE,SELECTCTID,A,3RDDAG60 STATE STDAIWETHERSFIELDDAJCTDAK061091896  DAQ119000555DARD   DASB         DAT     DBA20131107DBB19940101DBC1DBD20111115DAU601DAYBLUDBF00DBHY';
 
 var res = aamva.parse(data);
 
@@ -20,30 +20,22 @@ describe('address', function() {
 
 describe('gender', function() {
     it('should be set to MALE', function(){
-        expect(res.sex()).to.equal("MALE");
+        expect(res.sex).to.equal("MALE");
     });
 });
 
 describe('name', function() {
     it('first should be set to SELECTCTID', function(){
-        expect(res.name().first).to.equal("SELECTCTID");
+        expect(res.name.first).to.equal("SELECTCTID");
     });
     it('last should be set to REGULARLPSAMPLE', function(){
-        expect(res.name().last).to.equal("REGULARLPSAMPLE");
+        expect(res.name.last).to.equal("REGULARLPSAMPLE");
     });
 });
 
 describe('birthday', function() {
-    it('year should be 1995', function(){
-        expect(res.birthday().getUTCFullYear()).to.equal(1995);
-    });
-
-    it('month should be 11', function(){
-        expect(res.birthday().getUTCMonth()).to.equal(11);
-    });
-
-    it('day should be 07', function(){
-        expect(res.birthday().getUTCDate() ).to.equal(7);
+    it('year should be 19940101', function(){
+        expect(res.birthday).to.equal('19940101');
     });
 });
 
@@ -51,6 +43,5 @@ describe('postal_code', function() {
     it('should be 06109', function(){
         expect(res.postal_code).to.equal("06109");
     });
-
 });
 

--- a/test/PDF417_CT.js
+++ b/test/PDF417_CT.js
@@ -1,0 +1,56 @@
+var should = require('chai').should(),
+    expect = require('chai').expect,
+    aamva = require('../index');
+
+var data = '@AMVA 6360060101DL00290198DAAREGULARLPSAMPLE,SELECTCTID,A,3RDDAG60 STATE STDAIWETHERSFIELDDAJCTDAK061091896  DAQ119000555DARD   DASB         DAT     DBA20131107DBB19951107DBC1DBD20111115DAU601DAYBLUDBF00DBHY';
+
+var res = aamva.parse(data);
+
+describe('state', function() {
+    it('should be set to CT', function(){
+        expect(res.state).to.equal("CT");
+    });
+});
+
+describe('address', function() {
+    it('should be set to 60 STATE ST', function(){
+        expect(res.address).to.equal("60 STATE ST");
+    });
+});
+
+describe('gender', function() {
+    it('should be set to MALE', function(){
+        expect(res.sex()).to.equal("MALE");
+    });
+});
+
+describe('name', function() {
+    it('first should be set to SELECTCTID', function(){
+        expect(res.name().first).to.equal("SELECTCTID");
+    });
+    it('last should be set to REGULARLPSAMPLE', function(){
+        expect(res.name().last).to.equal("REGULARLPSAMPLE");
+    });
+});
+
+describe('birthday', function() {
+    it('year should be 1995', function(){
+        expect(res.birthday().getUTCFullYear()).to.equal(1995);
+    });
+
+    it('month should be 11', function(){
+        expect(res.birthday().getUTCMonth()).to.equal(11);
+    });
+
+    it('day should be 07', function(){
+        expect(res.birthday().getUTCDate() ).to.equal(7);
+    });
+});
+
+describe('postal_code', function() {
+    it('should be 06109', function(){
+        expect(res.postal_code).to.equal("06109");
+    });
+
+});
+

--- a/test/PDF417_FL.js
+++ b/test/PDF417_FL.js
@@ -21,30 +21,22 @@ describe('address', function() {
 
 describe('gender', function() {
     it('should be set to MALE', function(){
-        expect(res.sex()).to.equal("MALE");
+        expect(res.sex).to.equal("MALE");
     });
 });
 
 describe('name', function() {
     it('first should be set to JOHN', function(){
-        expect(res.name().first).to.equal("JOHN");
+        expect(res.name.first).to.equal("JOHN");
     });
     it('last should be set to DOE', function(){
-        expect(res.name().last).to.equal("DOE");
+        expect(res.name.last).to.equal("DOE");
     });
 });
 
 describe('birthday', function() {
-    it('year should be 1977', function(){
-        expect(res.birthday().getUTCFullYear()).to.equal(1977);
-    });
-
-    it('month should be 02', function(){
-        expect(res.birthday().getUTCMonth()).to.equal(2);
-    });
-
-    it('day should be 08', function(){
-        expect(res.birthday().getUTCDate() ).to.equal(8);
+    it('year should be 19770208', function(){
+        expect(res.birthday).to.equal('19770208');
     });
 });
 
@@ -52,5 +44,4 @@ describe('postal_code', function() {
     it('should be 44556', function(){
         expect(res.postal_code).to.equal("44556");
     });
-
 });

--- a/test/PDF417_MD.js
+++ b/test/PDF417_MD.js
@@ -21,30 +21,22 @@ describe('address', function() {
 
 describe('gender', function() {
     it('should be set to MALE', function(){
-        expect(res.sex()).to.equal("MALE");
+        expect(res.sex).to.equal("MALE");
     });
 });
 
 describe('name', function() {
     it('first should be set to JACK', function(){
-        expect(res.name().first).to.equal("JACK");
+        expect(res.name.first).to.equal("JACK");
     });
     it('last should be set to JOHNSON', function(){
-        expect(res.name().last).to.equal("JOHNSON");
+        expect(res.name.last).to.equal("JOHNSON");
     });
 });
 
 describe('birthday', function() {
-    it('year should be 1991', function(){
-        expect(res.birthday().getUTCFullYear()).to.equal(1991);
-    });
-
-    it('month should be 02', function(){
-        expect(res.birthday().getUTCMonth()).to.equal(2);
-    });
-
-    it('day should be 09', function(){
-        expect(res.birthday().getUTCDate() ).to.equal(9);
+    it('should be 19910209', function(){
+        expect(res.birthday).to.equal('19910209');
     });
 });
 
@@ -52,12 +44,11 @@ describe('postal_code', function() {
     it('should be 21230', function(){
         expect(res.postal_code).to.equal("21230");
     });
-
 });
 
 describe('id', function() {
     it('should be 21230', function(){
-        expect(res.id()).to.equal("K134123145103");
+        expect(res.id).to.equal("K134123145103");
     });
 
 });

--- a/test/PDF417_NH.js
+++ b/test/PDF417_NH.js
@@ -1,0 +1,57 @@
+var should = require('chai').should(),
+    expect = require('chai').expect,
+    aamva = require('../index');
+
+    var data = '@ANSI 111111030001DL01111111DCA DCB DCD DBA11111112DCSSMITH DCTJOHN A DBD03016013DBB10071990DBC1DAYBRODAU11 in DAG111 SMITHS ST DAISMITHSTON DAJNHDAK333333333 DAQ44NST44444 DCGUSADCHNONE';
+
+    var res = aamva.parse(data);
+
+describe('PDF417, NH', function() {
+  describe('state', function() {
+      it('should be set to NH', function(){
+          expect(res.state).to.equal("NH");
+      });
+  });
+
+  describe('address', function() {
+      it('should be set to 111 SMITHS ST', function(){
+          expect(res.address).to.equal("111 SMITHS ST");
+      });
+  });
+
+  describe('gender', function() {
+      it('should be set to MALE', function(){
+          expect(res.sex()).to.equal("MALE");
+      });
+  });
+
+  describe('name', function() {
+      it('first should be set to JOHN A', function(){
+          expect(res.name().first).to.equal("JOHN A");
+      });
+      it('last should be set to SMITH', function(){
+          expect(res.name().last).to.equal("SMITH");
+      });
+  });
+
+  describe('birthday', function() {
+      it('year should be 1990', function(){
+          expect(res.birthday().getUTCFullYear()).to.equal(1990);
+      });
+
+      it('month should be 10', function(){
+          expect(res.birthday().getUTCMonth()).to.equal(10);
+      });
+
+      it('day should be 07', function(){
+          expect(res.birthday().getUTCDate()).to.equal(7);
+      });
+  });
+
+  describe('postal_code', function() {
+      it('should be 33333', function(){
+          expect(res.postal_code).to.equal("33333");
+      });
+  });
+});
+

--- a/test/PDF417_NH.js
+++ b/test/PDF417_NH.js
@@ -21,30 +21,22 @@ describe('PDF417, NH', function() {
 
   describe('gender', function() {
       it('should be set to MALE', function(){
-          expect(res.sex()).to.equal("MALE");
+          expect(res.sex).to.equal("MALE");
       });
   });
 
   describe('name', function() {
       it('first should be set to JOHN A', function(){
-          expect(res.name().first).to.equal("JOHN A");
+          expect(res.name.first).to.equal("JOHN A");
       });
       it('last should be set to SMITH', function(){
-          expect(res.name().last).to.equal("SMITH");
+          expect(res.name.last).to.equal("SMITH");
       });
   });
 
   describe('birthday', function() {
-      it('year should be 1990', function(){
-          expect(res.birthday().getUTCFullYear()).to.equal(1990);
-      });
-
-      it('month should be 10', function(){
-          expect(res.birthday().getUTCMonth()).to.equal(10);
-      });
-
-      it('day should be 07', function(){
-          expect(res.birthday().getUTCDate()).to.equal(7);
+      it('year should be 19901007', function(){
+          expect(res.birthday).to.equal('19901007');
       });
   });
 

--- a/test/PDF417_TX.js
+++ b/test/PDF417_TX.js
@@ -21,30 +21,22 @@ describe('address', function() {
 
 describe('gender', function() {
     it('should be set to MALE', function(){
-        expect(res.sex()).to.equal("MALE");
+        expect(res.sex).to.equal("MALE");
     });
 });
 
 describe('name', function() {
     it('first should be set to JOHN', function(){
-        expect(res.name().first).to.equal("JOHN");
+        expect(res.name.first).to.equal("JOHN");
     });
     it('last should be set to DOE', function(){
-        expect(res.name().last).to.equal("DOE");
+        expect(res.name.last).to.equal("DOE");
     });
 });
 
 describe('birthday', function() {
-    it('year should be 1977', function(){
-        expect(res.birthday().getUTCFullYear()).to.equal(1977);
-    });
-
-    it('month should be 02', function(){
-        expect(res.birthday().getUTCMonth()).to.equal(2);
-    });
-
-    it('day should be 08', function(){
-        expect(res.birthday().getUTCDate() ).to.equal(8);
+    it('should be 02081977', function() {
+      expect(res.birthday).to.equal('19770208');
     });
 });
 

--- a/test/TX.js
+++ b/test/TX.js
@@ -22,19 +22,19 @@ describe('city', function() {
 
 describe('DMV ID', function() {
     it('should be set to 38774194', function(){
-    	expect(stripe.id()).to.equal("38774194");
+    	expect(stripe.id).to.equal("38774194");
     });
 });
 
 describe('First name', function() {
     it('should be set to JOHN', function(){
-    	expect(stripe.name().first).to.equal("JOHN");
+    	expect(stripe.name.first).to.equal("JOHN");
     });
 });
 
 describe('Last name', function() {
     it('should be set to DOE', function(){
-    	expect(stripe.name().last).to.equal("DOE");
+    	expect(stripe.name.last).to.equal("DOE");
     });
 });
 
@@ -46,13 +46,12 @@ describe('Address', function() {
 
 describe('Sex', function() {
     it('should be set to MALE', function(){
-    	expect(stripe.sex()).to.equal("MALE");
+    	expect(stripe.sex).to.equal("MALE");
     });
 });
 
 describe('DOB', function() {
-    it('should be set to 19810101', function(){
-        var date = new Date(Date.UTC(1981,0,1));
-        expect(stripe.birthday().toDateString()).to.equal(date.toDateString());
+    it('should be 1981010', function() {
+      expect(stripe.birthday).to.equal('19810101');
     });
 });


### PR DESCRIPTION
I made some fixes to PDF regexes. Version 3 was not working when some field in the middle was missing. Neither were working when last one is missing. Neither were capturing the last field.

In addition to that I added some more tests and changed date format to string of YYYYMMDD everywhere, so that it's uniform. I don't think we need a Date object since the fields have no time, and timezone is unknown.
